### PR TITLE
Replace `path` with `save_path` in documentation

### DIFF
--- a/docs/v6/index.md
+++ b/docs/v6/index.md
@@ -229,7 +229,7 @@ Add your application-specific settings:
 $settings['session'] = [
     'name' => 'app',
     'lifetime' => 7200,
-    'path' => null,
+    'save_path' => null,
     'domain' => null,
     'secure' => false,
     'httponly' => true,


### PR DESCRIPTION
There is no `session.path` configuration key in PHP, but there is `session.save_path`, which - I believe - is the right one to be communicated in docs.